### PR TITLE
Bump to latest conduit alpha and use `http` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,4 @@ repository = "https://github.com/conduit-rust/conduit-test"
 license = "MIT"
 
 [dependencies]
-conduit = "0.9.0-alpha.0"
-semver = "0.9"
+conduit = "0.9.0-alpha.1"


### PR DESCRIPTION
Based on upstream changes in conduit-rust/conduit#23

r? @JohnTitor